### PR TITLE
バグ修正-ユーザー毎のプロジェクト紐付け

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :authenticate_user!
 
   protected
 

--- a/app/controllers/break_rooms_controller.rb
+++ b/app/controllers/break_rooms_controller.rb
@@ -39,7 +39,7 @@ class BreakRoomsController < ApplicationController
   private
 
   def set_project
-    @project = Project.find(params[:project_id])
+    @project = current_user.projects.find(params[:project_id])
   end
 
   def set_break_room

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -30,7 +30,7 @@ class GroupsController < ApplicationController
 
   def update
     if @group.update(group_params)
-      redirect_to project_groups_path(@project), notice: "スタッフを更新しました"
+      redirect_to project_groups_path(@project)
     else
       render :edit, status: :unprocessable_entity
     end
@@ -39,7 +39,7 @@ class GroupsController < ApplicationController
   private
 
   def set_project
-    @project = Project.find(params[:project_id])
+    @project = current_user.projects.find(params[:project_id])
   end
 
   def set_group

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,20 +1,19 @@
 class ProjectsController < ApplicationController
-  before_action :authenticate_user!
   before_action :set_project, only: [ :edit, :update, :destroy ]
 
   def index
-    @projects = Project.all
+    @projects = current_user.projects
   end
 
   def new
-    @project = Project.new
+    @project = current_user.projects.new
   end
 
   def edit
   end
 
   def create
-    @project = Project.new(project_params)
+    @project = current_user.projects.new(project_params)
     if @project.save
       redirect_to projects_path, notice: "プロジェクトを作成しました"
     else
@@ -31,7 +30,7 @@ class ProjectsController < ApplicationController
   end
 
   def destroy
-    @project = Project.find(params[:id])
+    @project = current_user.projects.find(params[:id])
     @project.destroy
     redirect_to projects_path, notice: "プロジェクトを削除しました"
   end
@@ -40,7 +39,7 @@ class ProjectsController < ApplicationController
 
   # URLのidから該当プロジェクトを取得する共通処理
   def set_project
-    @project = Project.find(params[:id])
+    @project = current_user.projects.find(params[:id])
   end
 
   # ストロングパラメータnameだけを受け取る

--- a/app/controllers/shifts_controller.rb
+++ b/app/controllers/shifts_controller.rb
@@ -100,6 +100,6 @@ class ShiftsController < ApplicationController
   private
 
   def set_project
-    @project = Project.find(params[:project_id])
+    @project = current_user.projects.find(params[:project_id])
   end
 end

--- a/app/controllers/staffs_controller.rb
+++ b/app/controllers/staffs_controller.rb
@@ -24,7 +24,7 @@ class StaffsController < ApplicationController
 
   def update
     if @staff.update(staff_params)
-      redirect_to project_staffs_path(@project), notice: "スタッフを更新しました"
+      redirect_to project_staffs_path(@project)
     else
       render :edit, status: :unprocessable_entity
     end
@@ -38,7 +38,7 @@ class StaffsController < ApplicationController
   private
 
   def set_project
-    @project = Project.find(params[:project_id])
+    @project = current_user.projects.find(params[:project_id])
   end
 
   def set_staff

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,4 +1,5 @@
 class Project < ApplicationRecord
+  belongs_to :user
   has_many :staffs, dependent: :destroy
   has_many :shifts, dependent: :destroy
   has_many :groups, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,5 +5,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable,
          authentication_keys: [ :employee_code ]
 
+  has_many :projects, dependent: :destroy
+
   validates :employee_code, presence: true, uniqueness: true
 end

--- a/db/migrate/20250925125825_add_user_id_to_projects.rb
+++ b/db/migrate/20250925125825_add_user_id_to_projects.rb
@@ -1,0 +1,5 @@
+class AddUserIdToProjects < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :projects, :user, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_23_035843) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_25_125825) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -34,6 +34,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_23_035843) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_projects_on_user_id"
   end
 
   create_table "shift_details", force: :cascade do |t|
@@ -88,6 +90,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_23_035843) do
 
   add_foreign_key "break_rooms", "projects"
   add_foreign_key "groups", "projects"
+  add_foreign_key "projects", "users"
   add_foreign_key "shift_details", "shifts"
   add_foreign_key "shift_details", "staffs"
   add_foreign_key "shifts", "projects"


### PR DESCRIPTION
アカウントユーザー毎でプロジェクトが紐づけられておらず、
ログイン後のページがすべて共通となっていた重大バグを修正

- project.rbに　belongs_to :userカラムを追加しマイグレーションし修正
```
def index
    @projects = current_user.projects
  end
```

- URL直打ち対策 application_controllerに記載
